### PR TITLE
Remove `keytime-editor` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "eases": "^1.0.2",
     "inherits": "^2.0.1",
     "keyframes": "^2.2.1",
-    "keytime-editor": "0.0.3",
     "lerp-array": "^1.0.2",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
It seems that `keytime-editor` is only used in the demo.

`keytime-editor` depends on `dom-classes` and `dom-value`. They are not available on npm anymore; the original author unpublished all his modules from `npm`. I’m using `keytime` in [bemuse](https://github.com/bemusic/bemuse) project, where builds are failing now.
